### PR TITLE
Remove 'Cell' as superclass of 'germ line' Sep 30 2019

### DIFF
--- a/src/ontology/wbbt-edit.obda
+++ b/src/ontology/wbbt-edit.obda
@@ -5,6 +5,7 @@ owl:		http://www.w3.org/2002/07/owl#
 rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
 xml:		http://www.w3.org/XML/1998/namespace
 xsd:		http://www.w3.org/2001/XMLSchema#
+obda:		https://w3id.org/obda/vocabulary#
 rdfs:		http://www.w3.org/2000/01/rdf-schema#
 dcterms:		http://purl.org/dc/terms/
 

--- a/src/ontology/wbbt-edit.obda
+++ b/src/ontology/wbbt-edit.obda
@@ -1,0 +1,13 @@
+[PrefixDeclaration]
+:		http://purl.obolibrary.org/obo/wbbt.owl/
+dce:		http://purl.org/dc/elements/1.1/
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:		http://www.w3.org/XML/1998/namespace
+xsd:		http://www.w3.org/2001/XMLSchema#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+dcterms:		http://purl.org/dc/terms/
+
+[MappingDeclaration] @collection [[
+]]
+

--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Mon Sep 30 09:42:29 EDT 2019
+#Mon Sep 30 10:02:37 EDT 2019
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=316395bf-74af-4c2a-a4dc-e47c8081b858
+jdbc.name=e5410b4a-c5c6-451b-9585-649fcbca5dea
 jdbc.password=

--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,0 +1,6 @@
+#Mon Sep 30 09:42:29 EDT 2019
+jdbc.url=
+jdbc.driver=
+jdbc.user=
+jdbc.name=316395bf-74af-4c2a-a4dc-e47c8081b858
+jdbc.password=

--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Mon Sep 30 10:02:37 EDT 2019
+#Thu Oct 03 13:13:17 EDT 2019
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=e5410b4a-c5c6-451b-9585-649fcbca5dea
+jdbc.name=595d423f-da0c-4510-bdd1-65eee2f65cc2
 jdbc.password=


### PR DESCRIPTION
The anatomy term 'germ line' should not be a subclass of 'Cell', so removing 'Cell' as a superclass of 'germ line'