### PR TITLE
Added missing ciliated neurons as subclasses of 'ciliated neuron' class

### DIFF
--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Thu Oct 03 13:13:17 EDT 2019
+#Fri Oct 04 11:21:25 EDT 2019
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=595d423f-da0c-4510-bdd1-65eee2f65cc2
+jdbc.name=119ab621-548f-4075-8a9b-c9e8343990ec
 jdbc.password=

--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Fri Oct 04 11:21:25 EDT 2019
+#Fri Oct 04 15:38:12 EDT 2019
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=119ab621-548f-4075-8a9b-c9e8343990ec
+jdbc.name=0280f41d-204b-40b4-b425-0ca3394086f8
 jdbc.password=


### PR DESCRIPTION
Takes care of issue #9 

Added the following neuron classes as subclasses of 'ciliated neuron':

PVR
CEM
HOA
HOB
PCA
ray neuron type A
ray neuron type B
SPD
SPV

I debated (to myself) whether to just add 'HO neuron' and 'ray neuron' to the 'ciliated neuron' class as it seems HOA and HOB are all of the HO neurons and 'ray neuron type A' and 'ray neuron type B' are all of the ray neurons. I can do that instead if we prefer.