### PR TITLE
Add cross reference to CL "Cell" term

### DIFF
--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Fri Oct 25 12:29:51 EDT 2019
+#Thu Feb 27 12:21:25 EST 2020
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=9721bef4-b9d0-458e-af4f-c1958eee39a0
+jdbc.name=39e3782e-b24d-4268-a39d-4af866cdd1af
 jdbc.password=


### PR DESCRIPTION
By request from UPheno and Uberon groups:

Add a "database_cross_reference" annotation from the worm "Cell" (WBbt:0004017) to the CL term "cell" (CL:0000000).