### PR TITLE
Add ID and namespace to gonad arm

### DIFF
--- a/src/ontology/wbbt-edit.properties
+++ b/src/ontology/wbbt-edit.properties
@@ -1,6 +1,6 @@
-#Thu Apr 23 15:57:21 EDT 2020
+#Fri May 17 15:36:33 EDT 2024
+jdbc.password=
+jdbc.user=
+jdbc.name=f6ba882b-fb39-4ef2-83c3-037e6f6f8a14
 jdbc.url=
 jdbc.driver=
-jdbc.user=
-jdbc.name=37bccb81-9729-46ca-b9b3-0bf480dde2cb
-jdbc.password=


### PR DESCRIPTION
In order to load the term "gonad arm" into the Alliance persistent store, it needs its ID and namespace